### PR TITLE
Add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.ipynb_checkpoints/


### PR DESCRIPTION
When a Jupyter notebook is manually saved a backup is stored in the
.ipynb_checkpoints directory. The latest backup can be restored. There
is no need to track these backups with git and the added .gitignore
file ensures that this does not happen.