### PR TITLE
Add a Quantity example to lecture 3 (plotting)

### DIFF
--- a/Lecture3/Lecture3_manual.ipynb
+++ b/Lecture3/Lecture3_manual.ipynb
@@ -62,7 +62,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax =plt.subplots()\n",
+    "fig, ax = plt.subplots()\n",
     "ax.scatter(x, y, label='Markers')\n",
     "ax.plot(x, simple_function(x), label='Line', color='r')\n",
     "ax.legend(title='Legend')\n",
@@ -176,7 +176,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.plot(offsets+x[:,np.newaxis], y_mult)\n",
+    "x_mult = offsets + x[:,np.newaxis]\n",
+    "\n",
+    "print(f'Shape of x_mult:{x_mult.shape}.')\n",
+    "print(f'Shape of y_mult:{y_mult.shape}.')\n",
+    "plt.plot(offsets2d, y_mult)\n",
     "plt.legend(title='Offsets', labels=offsets)\n",
     "plt.show()"
    ]
@@ -510,12 +514,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Contour lines\n",
     "plt.contour(xx, yy, z)\n",
     "plt.colorbar()\n",
     "plt.gca().set_aspect('equal')\n",
     "plt.show()\n",
     "\n",
+    "# Filled contours\n",
     "plt.contourf(x, y, z)\n",
+    "plt.colorbar()\n",
+    "plt.gca().set_aspect('equal')\n",
+    "plt.show()\n",
+    "\n",
+    "# A mixture of both\n",
+    "plt.contour(x, y, z, colors='k')\n",
+    "plt.contourf(xx, yy, z)\n",
     "plt.colorbar()\n",
     "plt.gca().set_aspect('equal')\n",
     "plt.show()"
@@ -647,7 +660,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Add an example of how to use the Astropy Quantity class together with Matplotlib to ensure that the values in a plot are always in the units the plot claims them to be in.