### PR TITLE
Update the `matplotlib` presentation

### DIFF
--- a/3-plotting/presentation.ipynb
+++ b/3-plotting/presentation.ipynb
@@ -82,7 +82,7 @@
     }
    },
    "source": [
-    "Matplotlib is designed to be similar to MATLAB, so if you have ever used MATLAB you will feel familiar."
+    "`matplotlib` is designed to be similar to MATLAB, so if you have ever used MATLAB you will feel familiar."
    ]
   },
   {
@@ -93,7 +93,7 @@
     }
    },
    "source": [
-    "Matplotlib will let you graph your data on a *Figure*. That Figure contains one or more *Axes*. To explain this, let's consider the following illustration:\n",
+    "`matplotlib` will let you graph your data on a `Figure`. That `Figure` contains one or more `Axes`. To explain this, let's consider the following illustration:\n",
     "\n",
     "<img src=\"imgs/anatomy.png\" width=\"900\" align=\"left\" style=\"margin: 0px 0px 0px 350px;\"/>\n",
     "\n"
@@ -110,16 +110,20 @@
     "<img src=\"imgs/anatomy.png\" width=\"900\" align=\"right\" style=\"margin: 0px 0px 0px 0px;\"/>\n",
     "\n",
     "#### <span style=\"color:red\">Figure</span>\n",
-    "The entire plotted thing. Contains all child Axes. Think of it as a paper you will draw on.\n",
+    "The entire plotted thing.\n",
+    "Contains all child  <span style=\"color:magenta\">Axes</span>.\n",
+    "Think of it as a paper you will draw on.\n",
     "\n",
     "#### <span style=\"color:magenta\">Axes</span>\n",
-    "This is the plot itself. You might have 2 Axes next to each other in a single figure. Contains 2 <span style=\"color:green\">*Axis*</span> objects, 3 for 3D plots.\n",
+    "This is the plot itself.\n",
+    "You might have 2 <span style=\"color:magenta\">Axes</span> next to each other in a single figure.\n",
+    "Contains 2 <span style=\"color:green\">Axis</span> objects, 3 for 3D plots.\n",
     "\n",
     "#### <span style=\"color:green\">Axis</span>\n",
     "Sets the graph limit. Takes care of ticks.\n",
     "\n",
     "#### <span style=\"color:blue\">Artist</span>\n",
-    "Everything *on* the figure is typically an artist (including the <span style=\"color:red\">Figure</span>, <span style=\"color:magenta\">Axes</span>, and <span style=\"color:green\">*Axis*</span> objects)"
+    "Everything *on* the figure is typically an artist (including the <span style=\"color:red\">Figure</span>, <span style=\"color:magenta\">Axes</span>, and <span style=\"color:green\">Axis</span> objects)"
    ]
   },
   {
@@ -145,8 +149,11 @@
     }
    },
    "source": [
-    "You can either make your plots *Object Oriented* or with pyplot. \n",
-    "#### Object oriented:"
+    "`matplotlib` allows plots to be made using [two different interfaces](https://matplotlib.org/stable/tutorials/introductory/usage.html?highlight=interface#the-object-oriented-interface-and-the-pyplot-interface).\n",
+    "\n",
+    "#### Object-oriented interface:\n",
+    "\n",
+    "This means explicitly creating all the `Figure` and `Axes` objects and calling their methods."
    ]
   },
   {
@@ -159,13 +166,13 @@
    },
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots()  # Create a figure and an axes.\n",
+    "fig, ax = plt.subplots()                # Create a figure and an axes.\n",
     "ax.plot(x, x**2, label='linear')        # Plot some data on the axes.\n",
     "ax.plot(x, 2*x**2, label='quadratic')   # Plot more data on the axes...\n",
     "ax.plot(x, 4*x**2, label='cubic')       # ... and some more.\n",
     "ax.set_xlabel('x label')                # Add a label to the x-axis.\n",
     "ax.set_ylabel('y label')                # Add a label to the y-axis.\n",
-    "ax.set_title(\"Simple Plot\")             # Add a title.\n",
+    "ax.set_title('Simple Plot')             # Add a title.\n",
     "ax.legend()                             # Add a legend.\n",
     "plt.show()"
    ]
@@ -178,7 +185,9 @@
     }
    },
    "source": [
-    "#### Pyplot (I prefer this)"
+    "#### Pyplot  interface:\n",
+    "\n",
+    "This means letting `pyplot` take care of managing `Figure` and `Axes` objects."
    ]
   },
   {
@@ -198,7 +207,7 @@
     "plt.plot(x, 4*x**2, label='cubic')\n",
     "plt.xlabel('x label')\n",
     "plt.ylabel('y label')\n",
-    "plt.title(\"Simple Plot\")\n",
+    "plt.title('Simple Plot')\n",
     "plt.legend()\n",
     "plt.show()"
    ]
@@ -256,53 +265,6 @@
     }
    },
    "source": [
-    "#### presentation.mplstyle\n",
-    "<img src=\"imgs/stretch.png\" width=\"1.5\" align=\"left\" style=\"margin: 0px 0px 0px 0px;\"/>\n",
-    "<p style=\"line-height:17px\">\n",
-    "<code style=\"font-family;font-size:15pt;\">font.size            : </code><code style=\"color:green;font-size:15pt\">20         </code><br>\n",
-    "<code style=\"font-family;font-size:15pt;\">axes.linewidth       : </code><code style=\"color:green;font-size:15pt\">1.2        </code><br>\n",
-    "<code style=\"font-family;font-size:15pt;\">axes.grid            : </code><code style=\"color:green;font-size:15pt\">False      </code><br>\n",
-    "<code style=\"font-family;font-size:15pt;\">axes.axisbelow       : </code><code style=\"color:green;font-size:15pt\">False      </code><br>\n",
-    "<code style=\"font-family;font-size:15pt;\">figure.figsize       : </code><code style=\"color:green;font-size:15pt\">8.0, 6.0   </code><br>\n",
-    "<code style=\"font-family;font-size:15pt;\">figure.frameon       : </code><code style=\"color:green;font-size:15pt\">True       </code><br>\n",
-    "<code style=\"font-family;font-size:15pt;\">axes.labelsize       : </code><code style=\"color:green;font-size:15pt\">20         </code><br>\n",
-    "<code style=\"font-family;font-size:15pt;\">xtick.labelsize      : </code><code style=\"color:green;font-size:15pt\">16         </code><br>\n",
-    "<code style=\"font-family;font-size:15pt;\">xtick.direction      : </code><code style=\"color:green;font-size:15pt\">in         </code><br>\n",
-    "<code style=\"font-family;font-size:15pt;\">xtick.top            : </code><code style=\"color:green;font-size:15pt\">True       </code><br>\n",
-    "<code style=\"font-family;font-size:15pt;\">xtick.bottom         : </code><code style=\"color:green;font-size:15pt\">True       </code><br>\n",
-    "<code style=\"font-family;font-size:15pt;\">xtick.major.size     : </code><code style=\"color:green;font-size:15pt\">7.5        </code><br>\n",
-    "<code style=\"font-family;font-size:15pt;\">xtick.minor.size     : </code><code style=\"color:green;font-size:15pt\">3.5        </code><br>\n",
-    "<code style=\"font-family;font-size:15pt;\">xtick.major.width    : </code><code style=\"color:green;font-size:15pt\">1          </code><br>\n",
-    "<code style=\"font-family;font-size:15pt;\">xtick.minor.width    : </code><code style=\"color:green;font-size:15pt\">1          </code><br>\n",
-    "<code style=\"font-family;font-size:15pt;\">xtick.minor.visible  : </code><code style=\"color:green;font-size:15pt\">True       </code><br>\n",
-    "<code style=\"font-family;font-size:15pt;\">xtick.major.top      : </code><code style=\"color:green;font-size:15pt\">True       </code><br>\n",
-    "<code style=\"font-family;font-size:15pt;\">xtick.major.bottom   : </code><code style=\"color:green;font-size:15pt\">True       </code><br>\n",
-    "<code style=\"font-family;font-size:15pt;\">xtick.minor.top      : </code><code style=\"color:green;font-size:15pt\">True       </code><br>\n",
-    "<code style=\"font-family;font-size:15pt;\">xtick.minor.bottom   : </code><code style=\"color:green;font-size:15pt\">True       </code><br>\n",
-    "<code style=\"font-family;font-size:15pt;\">ytick.direction      : </code><code style=\"color:green;font-size:15pt\">in         </code><br>\n",
-    "<code style=\"font-family;font-size:15pt;\">ytick.labelsize      : </code><code style=\"color:green;font-size:15pt\">16         </code><br>\n",
-    "<code style=\"font-family;font-size:15pt;\">ytick.minor.visible  : </code><code style=\"color:green;font-size:15pt\">True       </code><br>\n",
-    "<code style=\"font-family;font-size:15pt;\">ytick.major.right    : </code><code style=\"color:green;font-size:15pt\">True       </code><br>\n",
-    "<code style=\"font-family;font-size:15pt;\">ytick.major.left     : </code><code style=\"color:green;font-size:15pt\">True       </code><br>\n",
-    "<code style=\"font-family;font-size:15pt;\">ytick.minor.right    : </code><code style=\"color:green;font-size:15pt\">True       </code><br>\n",
-    "<code style=\"font-family;font-size:15pt;\">ytick.minor.left     : </code><code style=\"color:green;font-size:15pt\">True       </code><br>\n",
-    "<code style=\"font-family;font-size:15pt;\">ytick.right          : </code><code style=\"color:green;font-size:15pt\">True       </code><br>\n",
-    "<code style=\"font-family;font-size:15pt;\">ytick.left           : </code><code style=\"color:green;font-size:15pt\">True       </code><br>\n",
-    "<code style=\"font-family;font-size:15pt;\">ytick.major.size     : </code><code style=\"color:green;font-size:15pt\">7.5        </code><br>\n",
-    "<code style=\"font-family;font-size:15pt;\">ytick.minor.size     : </code><code style=\"color:green;font-size:15pt\">3.5        </code><br>\n",
-    "<code style=\"font-family;font-size:15pt;\">ytick.major.width    : </code><code style=\"color:green;font-size:15pt\">1          </code><br>\n",
-    "<code style=\"font-family;font-size:15pt;\">ytick.minor.width    : </code><code style=\"color:green;font-size:15pt\">1          </code><br>\n",
-    "</p>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
-   "source": [
     "### Types of plots\n",
     "\n",
     "Generate some data to plot:"
@@ -319,14 +281,22 @@
    },
    "outputs": [],
    "source": [
-    "x1 = np.random.normal(size=100)\n",
-    "x2 = np.linspace(0, 5, 100)\n",
-    "y2 = (x2**2) - x + np.random.normal(size=x2.size)\n",
+    "from numpy.random import default_rng\n",
     "\n",
-    "x3, y3 = np.vstack((\n",
-    "        np.random.multivariate_normal(mean=[-3, 0], cov=[[0.5, 0], [0, 0.5]], size=40000),\n",
-    "        +np.random.multivariate_normal(mean=[-1, 2], cov=[[1, 0], [0, 0.3]], size=20000),\n",
-    "        +np.random.multivariate_normal(mean=[-3, 2], cov=[[0.7, 0], [0, 0.5]], size=40000))).T"
+    "rng = default_rng()\n",
+    "\n",
+    "x1 = rng.standard_normal(size=100)\n",
+    "x2 = np.linspace(0, 5, 100)\n",
+    "y2 = x2**2 - x + rng.standard_normal(size=x2.size)\n",
+    "\n",
+    "data3 = np.empty((100_000, 2))\n",
+    "filled_index = 0\n",
+    "for mean, cov, size in zip(([-3, 0], [-1, 2], [-3, 2]),\n",
+    "                           ([[0.5, 0], [0, 0.5]], [[1, 0], [0, 0.3]], [[0.7, 0], [0, 0.5]]),\n",
+    "                           ([40_000, 20_000, 40_000])):\n",
+    "    data3[filled_index:filled_index+size] = rng.multivariate_normal(mean=mean, cov=cov, size=size)\n",
+    "    filled_index += size\n",
+    "x3, y3 = data3.T"
    ]
   },
   {
@@ -417,8 +387,8 @@
    "outputs": [],
    "source": [
     "plt.figure(figsize=(6, 6))\n",
-    "x = np.random.uniform(0, 10, size=200)\n",
-    "y = np.random.uniform(0, 10, size=200)\n",
+    "x = rng.uniform(0, 10, size=200)\n",
+    "y = rng.uniform(0, 10, size=200)\n",
     "plt.scatter(x, y, c='k')\n",
     "plt.show()"
    ]
@@ -433,30 +403,18 @@
    },
    "outputs": [],
    "source": [
-    "plt.figure(figsize=(10, 8))             # Create the figure, here we specify the figure size\n",
-    "\n",
-    "plt.scatter(x, y, s=x*y**2, c=-y+x**2,  # Create scatter plot, add colour by X, select cmap \"hot\"\n",
-    "            cmap='hot', label='Log(x)')\n",
-    "\n",
-    "plt.xlabel('$x$ value')                 # Add a label to the x-axis\n",
-    "plt.xticks(ticks=[-1, 3, 7, 11],        # Modify the ticklabels!\n",
-    "           labels=['$x_1$', '$x_2$',\n",
-    "           '$x_3$', '$x_4$'])\n",
-    "\n",
-    "plt.ylabel('$y$ value')                 # Add a label to the y-axis\n",
-    "\n",
-    "plt.minorticks_on()                     # Create small ticks between the big ones\n",
-    "plt.tick_params(which='both',           # Modify the tickmarks to go in both directions\n",
-    "                direction='inout')\n",
-    "plt.title('Plot of log($x$)')           # Add a title\n",
-    "plt.legend(fancybox=True,               # Create a legend and specify its location\n",
-    "           loc='lower right')\n",
-    "\n",
-    "cbar = plt.colorbar()                   # Add a colorbar (We could also specify the mappable)\n",
-    "cbar.set_label('Colobar label')         # Here we create a label for the colorbar\n",
+    "plt.figure(figsize=(10, 8))\n",
+    "plt.scatter(x, y, s=x*y**2, c=-y+x**2, cmap='hot', label='Log(x)')\n",
+    "plt.xlabel('$x$ value')\n",
+    "plt.xticks(ticks=range(-1, 12, 4), labels=[f'$x_{i}$' for i in range(1, 5)])\n",
+    "plt.ylabel('$y$ value')\n",
+    "plt.minorticks_on()\n",
+    "plt.tick_params(which='both', direction='inout')\n",
+    "plt.title('Plot of log($x$)')\n",
+    "plt.legend(fancybox=True, loc='lower right')\n",
+    "plt.colorbar(label='Colobar label')\n",
     "plt.gca().set_axisbelow(True)\n",
-    "plt.grid()                              # Add a grid to the plot\n",
-    "plt.box(True)                           # Activate/Deactivate the box around the plot\n",
+    "plt.grid()\n",
     "plt.show()"
    ]
   },
@@ -498,7 +456,6 @@
     }
    },
    "source": [
-    "What's wrong with this figure?\n",
     "<center>\n",
     "    <img src=\"imgs/bad3.png\" width=\"900\" align=\"middle\" style=\"margin: 0px 0px 0px 0px;\"/>\n",
     "</center>"
@@ -512,7 +469,6 @@
     }
    },
    "source": [
-    "What's wrong with this figure?\n",
     "<center>\n",
     "    <img src=\"imgs/bad4.png\" width=\"1000\" align=\"middle\" style=\"margin: 0px 0px 0px 0px;\"/>\n",
     "</center>"
@@ -526,7 +482,6 @@
     }
    },
    "source": [
-    "What's wrong with this figure?\n",
     "<center>\n",
     "    <img src=\"imgs/bad5.png\" width=\"1300\" align=\"middle\" style=\"margin: 0px 0px 0px 0px;\"/>\n",
     "</center>"
@@ -555,30 +510,6 @@
    },
    "source": [
     "From: [Mikkola et al. 2020](https://ui.adsabs.harvard.edu/abs/2020MNRAS.495.3295M/abstract)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "scrolled": false,
-    "slideshow": {
-     "slide_type": "slide"
-    }
-   },
-   "source": [
-    "### How to make your plots good in 10 rules:\n",
-    "<p style=\"line-height:85px\">\n",
-    "<span style=\"font-size:30pt;\">1. Know the purpose of your plot.</span><br>\n",
-    "<span style=\"font-size:30pt;\">2. Make sure your plot is readable where you put it (final pdf or similar).</span><br>\n",
-    "<span style=\"font-size:30pt;\">3. Captions are not optional. Captions are descriptive.</span><br>\n",
-    "<span style=\"font-size:30pt;\">4. Never trust default settings. Default settings are good for any plot but best for none.</span><br>\n",
-    "<span style=\"font-size:30pt;\">5. Use colors to your advantage. Don't overuse. </span><br>\n",
-    "<span style=\"font-size:30pt;\">6. Don't mislead the reader. For example, lines through markers can imply a pattern.</span><br>\n",
-    "<span style=\"font-size:30pt;\">7. Keep your plots from being too crowded. </span><br>\n",
-    "<span style=\"font-size:30pt;\">8. Always include units.</span><br>\n",
-    "<span style=\"font-size:30pt;\">9. Fontsize. Fontsize. <strong>Fontsize</strong>.</span><br>\n",
-    "<span style=\"font-size:30pt;\">10. Find the right plot for what you're trying to show</span><br>\n",
-    "</p>\n"
    ]
   },
   {
@@ -622,7 +553,7 @@
     }
    },
    "source": [
-    "Always save your plots as vector images.\n",
+    "Always prefer saving your plots as vector images.\n",
     "\n",
     "**Common Formats**\n",
     "\n",
@@ -630,12 +561,37 @@
     "\n",
     "Raster images: *JPEG, PNG, GIF*  \n",
     "\n",
-    "If you have a lot of data points, the vector images can be cumbersome to work with. You can rasterize the plot but keep the axis elements vector. \n",
+    "If you have a lot of data points, the vector images can be cumbersome to work with.\n",
+    "You can rasterize the plot but keep the axis elements in vector format. \n",
     "\n",
     "```python\n",
     "plt.plot(x, y, rasterized=True)\n",
     "plt.savefig('filename.pdf', format='pdf')\n",
     "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "scrolled": false,
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "### How to make your plots good in 10 rules:\n",
+    "<p style=\"line-height:85px\">\n",
+    "<span style=\"font-size:30pt;\">1. Know the purpose of your plot.</span><br>\n",
+    "<span style=\"font-size:30pt;\">2. Make sure your plot is readable where you put it (final pdf or similar).</span><br>\n",
+    "<span style=\"font-size:30pt;\">3. Captions are not optional. Captions are descriptive.</span><br>\n",
+    "<span style=\"font-size:30pt;\">4. Never trust default settings. Default settings are good for any plot but best for none.</span><br>\n",
+    "<span style=\"font-size:30pt;\">5. Use colors to your advantage. Don't overuse. </span><br>\n",
+    "<span style=\"font-size:30pt;\">6. Don't mislead the reader. For example, lines through markers can imply a pattern.</span><br>\n",
+    "<span style=\"font-size:30pt;\">7. Keep your plots from being too crowded. </span><br>\n",
+    "<span style=\"font-size:30pt;\">8. Always include units.</span><br>\n",
+    "<span style=\"font-size:30pt;\">9. Fontsize. Fontsize. <strong>Fontsize</strong>.</span><br>\n",
+    "<span style=\"font-size:30pt;\">10. Find the right plot for what you're trying to show</span><br>\n",
+    "</p>\n"
    ]
   },
   {


### PR DESCRIPTION
Most of the updates are minor style changes. However, the slide showing the contents of a `matplotlib` style file has been removed because handing it out is much more useful than showing its contents on a slide.

There are still a few things that need to be updated in the first few and last few slides (e.g. names on the title slide), but I am not planning to further update the contents of the lecture itself.