### PR TITLE
Update image links to new host

### DIFF
--- a/1-intro/manual.ipynb
+++ b/1-intro/manual.ipynb
@@ -811,7 +811,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -825,7 +825,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/1-intro/presentation.ipynb
+++ b/1-intro/presentation.ipynb
@@ -8,7 +8,7 @@
     }
    },
    "source": [
-    "<img src=\"https://mikkolad.github.io/lundpython/imgs/front_1.png\" width=\"1400\">"
+    "<img src=\"https://lund-observatory-teaching.github.io/lundpython/imgs/front_1.png\" width=\"1400\">"
    ]
   },
   {
@@ -21,7 +21,7 @@
    "source": [
     "<h1><center> The course </center></h1>\n",
     "\n",
-    "#### Prior lecturers - Daniel Carrera, Brian Thorsbro\n",
+    "#### Prior lecturers - Daniel Carrera, Brian Thorsbro, Daniel Mikkola\n",
     "<br>\n",
     "<br>\n",
     "\n",
@@ -50,7 +50,7 @@
     "\n",
     "To download all lecture files and see the schedule, please visit:\n",
     "\n",
-    "[mikkolad.github.io/lundpython/](https://mikkolad.github.io/lundpython/)\n",
+    "[lund-observatory-teaching.github.io/lundpython/](https://lund-observatory-teaching.github.io/lundpython/)\n",
     "\n",
     "\n",
     "Each lecture contains (as notebooks)\n",
@@ -86,7 +86,7 @@
     "Not only is it one of the most used languages in the world it is also one of the most versatile.\n",
     "The below table is from [HackerRank's 2020 report](https://research.hackerrank.com/developer-skills/2020).\n",
     "\n",
-    "<img src=\"https://mikkolad.github.io/lundpython/imgs/languages.png\" width=\"900\">\n",
+    "<img src=\"https://lund-observatory-teaching.github.io/lundpython/imgs/languages.png\" width=\"900\">\n",
     "\n",
     "Knowing this, let's review some of the things Python is used for!"
    ]
@@ -103,7 +103,7 @@
     "\n",
     "HackerRank showed in a [blogpost from 2016](https://blog.hackerrank.com/emerging-languages-still-overshadowed-by-incumbents-java-python-in-coding-interviews/) that when hiring developers/programmers, the prioritized programming languages for finance always had Python ranked high. \n",
     "\n",
-    "<img src=\"https://mikkolad.github.io/lundpython/imgs/finance.png\"   width=1400 height=500/>  "
+    "<img src=\"https://lund-observatory-teaching.github.io/lundpython/imgs/finance.png\"   width=1400 height=500/>  "
    ]
   },
   {
@@ -119,7 +119,7 @@
     "\n",
     "In fact, **reddit** is written in Python and available on GitHub (https://github.com/reddit-archive/reddit)!\n",
     "\n",
-    "<img src=\"https://mikkolad.github.io/lundpython/imgs/reddit.png\" width=\"1500\">"
+    "<img src=\"https://lund-observatory-teaching.github.io/lundpython/imgs/reddit.png\" width=\"1500\">"
    ]
   },
   {
@@ -157,7 +157,7 @@
     }
    },
    "source": [
-    "<img src=\"https://mikkolad.github.io/lundpython/imgs/astropy.png\"    width=\"400\" align=\"right\" style=\"margin: 0px 0px 0px 0px;\"/> \n",
+    "<img src=\"https://lund-observatory-teaching.github.io/lundpython/imgs/astropy.png\"    width=\"400\" align=\"right\" style=\"margin: 0px 0px 0px 0px;\"/> \n",
     "\n",
     "- [Astropy](https://www.astropy.org): Astronomy"
    ]
@@ -170,7 +170,7 @@
     }
    },
    "source": [
-    "<img src=\"https://mikkolad.github.io/lundpython/imgs/biopython.png\"  width=\"260\" align=\"right\" style=\"margin: 0px 140px 0px 0px;\"/>  \n",
+    "<img src=\"https://lund-observatory-teaching.github.io/lundpython/imgs/biopython.png\"  width=\"260\" align=\"right\" style=\"margin: 0px 140px 0px 0px;\"/>  \n",
     "\n",
     "\n",
     "- [Biopython](https://biopython.org): Biology & Bioinformatics"
@@ -184,7 +184,7 @@
     }
    },
    "source": [
-    "<img src=\"https://mikkolad.github.io/lundpython/imgs/graph-tool.png\" width=\"400\" align=\"right\" style=\"margin: 0px 0px 10px 0px;\"/>  \n",
+    "<img src=\"https://lund-observatory-teaching.github.io/lundpython/imgs/graph-tool.png\" width=\"400\" align=\"right\" style=\"margin: 0px 0px 10px 0px;\"/>  \n",
     "\n",
     "- [Graph-tool](https://graph-tool.skewed.de): Statistical analysis of graphs"
    ]
@@ -197,7 +197,7 @@
     }
    },
    "source": [
-    "<img src=\"https://mikkolad.github.io/lundpython/imgs/psychopy.png\"   width=\"290\" align=\"right\" style=\"margin: 0px 110px 0px 0px;\"/>\n",
+    "<img src=\"https://lund-observatory-teaching.github.io/lundpython/imgs/psychopy.png\"   width=\"290\" align=\"right\" style=\"margin: 0px 110px 0px 0px;\"/>\n",
     "\n",
     "- [Psychopy](https://www.psychopy.org): Neuroscience & Experimental Psychology"
    ]
@@ -225,13 +225,11 @@
    "source": [
     "<h1><center> Writing Python </center></h1>\n",
     "\n",
-    "<img src=\"https://upload.wikimedia.org/wikipedia/en/c/cd/Anaconda_Logo.png\" width=\"300\" align=\"left\" style=\"margin: 0px 160px 60px 60px;\"/>\n",
+    "We recommend following the guide made by Numpy for installing Python:\n",
     "\n",
-    "We recommend installing Python through Anaconda. \n",
+    "[https://numpy.org/install/](https://numpy.org/install/#python-numpy-install-guide)\n",
     "\n",
-    "Get Anaconda from:\n",
-    "\n",
-    "[https://www.anaconda.com/download/](https://www.anaconda.com/download/)"
+    "It covers all cases with differnt operating systems and user experience levels. "
    ]
   },
   {
@@ -1020,7 +1018,7 @@
  "metadata": {
   "celltoolbar": "Slideshow",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1034,7 +1032,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/2-numpy/exercises.ipynb
+++ b/2-numpy/exercises.ipynb
@@ -589,7 +589,7 @@
     "With these two arrays, calculate a new 4x3 array called `arr_c` where each of the rows are the rows of `arr_a` multiplied by `arr_b`. \n",
     "\n",
     "An illustration of the calculation you are to make:  \n",
-    "![](https://mikkolad.github.io/lundpython/imgs/broadcasting.png)\n",
+    "![](https://lund-observatory-teaching.github.io/lundpython/imgs/broadcasting.png)\n",
     "\n",
     "#### Perform this calculation \n",
     "#### a) without NumPy broadcasting\n",
@@ -661,7 +661,7 @@
     "<br>\n",
     "<br>\n",
     "2. You have some data which clearly has noise. You want to fit a line through it like in the figure below. How can SciPy do this?\n",
-    "![](https://mikkolad.github.io/lundpython/imgs/fitting.png)\n",
+    "![](https://lund-observatory-teaching.github.io/lundpython/imgs/fitting.png)\n",
     "<br>\n",
     "    <details>\n",
     "      <summary>Click here for a hint</summary>\n",
@@ -675,7 +675,7 @@
     "<br>\n",
     "\n",
     "3. You have a photo like below which unfortunately is rather pixelized. You hate pixelized images and instead want to use interpolation to get rid of the ugly bins and make it look like it does on the right. How can SciPy do this?\n",
-    "![](https://mikkolad.github.io/lundpython/imgs/interpolate.png)\n",
+    "![](https://lund-observatory-teaching.github.io/lundpython/imgs/interpolate.png)\n",
     "<br>\n",
     "    <details>\n",
     "      <summary>Click here for a hint</summary>\n",
@@ -934,7 +934,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -948,7 +948,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/2-numpy/presentation.ipynb
+++ b/2-numpy/presentation.ipynb
@@ -8,7 +8,7 @@
     }
    },
    "source": [
-    "<img src=\"https://mikkolad.github.io/lundpython/imgs/front_2.png\" width=\"1400\">"
+    "<img src=\"https://lund-observatory-teaching.github.io/lundpython/imgs/front_2.png\" width=\"1400\">"
    ]
   },
   {
@@ -23,7 +23,7 @@
     "\n",
     "To download all lecture files and see the schedule, please visit:\n",
     "\n",
-    "[mikkolad.github.io/lundpython/](https://mikkolad.github.io/lundpython/)\n",
+    "[lund-observatory-teaching.github.io/lundpython/](https://lund-observatory-teaching.github.io/lundpython/)\n",
     "\n",
     "Each lecture contains (as notebooks)\n",
     "- Manual \n",
@@ -81,7 +81,7 @@
     }
    },
    "source": [
-    "<img src=\"https://mikkolad.github.io/lundpython/imgs/numpy.png\" width=\"300\"/>\n",
+    "<img src=\"https://lund-observatory-teaching.github.io/lundpython/imgs/numpy.png\" width=\"300\"/>\n",
     "\n",
     "### What is NumPy?\n",
     "\n",
@@ -477,7 +477,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<img src=\"https://mikkolad.github.io/lundpython/imgs/indexing.png\" width=\"1600\" style=\"margin: 0pt 0pt 0pt 20pt;\"/>"
+    "<img src=\"https://lund-observatory-teaching.github.io/lundpython/imgs/indexing.png\" width=\"1600\" style=\"margin: 0pt 0pt 0pt 20pt;\"/>"
    ]
   },
   {
@@ -727,7 +727,7 @@
     "Typically it means that the smaller of the arrays is \"stretched\" out to match the larger's shape.\n",
     "For example:\n",
     "<br>\n",
-    "![](https://mikkolad.github.io/lundpython/imgs/np_multiply_broadcasting.png)"
+    "![](https://lund-observatory-teaching.github.io/lundpython/imgs/np_multiply_broadcasting.png)"
    ]
   },
   {
@@ -740,7 +740,7 @@
    "source": [
     "This can be rather useful for certain operations. For example consider the illustration below where we are simply doing the operation `arr_c = arr_a * arr_b`  \n",
     "<br>\n",
-    "![](https://mikkolad.github.io/lundpython/imgs/broadcasting.png)"
+    "![](https://lund-observatory-teaching.github.io/lundpython/imgs/broadcasting.png)"
    ]
   },
   {
@@ -902,7 +902,7 @@
     "\n",
     "A collection of mathematocal algorithms and convenience functions built on NumPy.  \n",
     "\n",
-    "![](https://mikkolad.github.io/lundpython/imgs/scipy_subpackages.png)"
+    "![](https://lund-observatory-teaching.github.io/lundpython/imgs/scipy_subpackages.png)"
    ]
   },
   {
@@ -917,7 +917,7 @@
     "\n",
     "Python packages developed for astronomers.  \n",
     "\n",
-    "![](https://mikkolad.github.io/lundpython/imgs/astropy.png)"
+    "![](https://lund-observatory-teaching.github.io/lundpython/imgs/astropy.png)"
    ]
   },
   {
@@ -1018,7 +1018,7 @@
  "metadata": {
   "celltoolbar": "Slideshow",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1032,7 +1032,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/3-plotting/exercises.ipynb
+++ b/3-plotting/exercises.ipynb
@@ -56,7 +56,7 @@
     "\n",
     "Your output should look like this:  \n",
     "\n",
-    "![](https://mikkolad.github.io/lundpython/imgs/figures.jpeg)"
+    "![](https://lund-observatory-teaching.github.io/lundpython/imgs/figures.jpeg)"
    ]
   },
   {
@@ -109,7 +109,7 @@
     "\n",
     "We made some improvements to the plot:\n",
     "\n",
-    "![](https://mikkolad.github.io/lundpython/imgs/figures_improved.jpeg)\n",
+    "![](https://lund-observatory-teaching.github.io/lundpython/imgs/figures_improved.jpeg)\n",
     "\n",
     "Every plot should include these changes we made: \n",
     "- Add a title.\n",
@@ -268,7 +268,7 @@
     "      \n",
     "  </details>\n",
     "  \n",
-    "  ![](https://mikkolad.github.io/lundpython/imgs/subplots.png)"
+    "  ![](https://lund-observatory-teaching.github.io/lundpython/imgs/subplots.png)"
    ]
   },
   {
@@ -319,7 +319,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -333,7 +333,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/3-plotting/presentation.ipynb
+++ b/3-plotting/presentation.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<img src=\"https://mikkolad.github.io/lundpython/imgs/front_3.png\" width=\"1400\">"
+    "<img src=\"https://lund-observatory-teaching.github.io/lundpython/imgs/front_3.png\" width=\"1400\">"
    ]
   },
   {
@@ -17,7 +17,7 @@
    "source": [
     "To download all lecture files and see the schedule, please visit:\n",
     "\n",
-    "[mikkolad.github.io/lundpython/](https://mikkolad.github.io/lundpython/)\n",
+    "[lund-observatory-teaching.github.io/lundpython/](https://lund-observatory-teaching.github.io/lundpython/)\n",
     "\n",
     "Each lecture contains (as notebooks)\n",
     "- Manual \n",
@@ -37,7 +37,7 @@
    "source": [
     "# Plotting in Python\n",
     "<br>\n",
-    "<img src=\"https://mikkolad.github.io/lundpython/imgs/matplotlib.png\" width=\"600\">\n",
+    "<img src=\"https://lund-observatory-teaching.github.io/lundpython/imgs/matplotlib.png\" width=\"600\">\n",
     "\n",
     "> [Matplotlib](https://matplotlib.org) is a comprehensive library for creating static, animated, and interactive visualizations in Python.\n",
     "\n",
@@ -90,7 +90,7 @@
    "source": [
     "`matplotlib` will let you graph your data on a `Figure`. That `Figure` contains one or more `Axes`. To explain this, let's consider the following illustration:\n",
     "\n",
-    "<img src=\"https://mikkolad.github.io/lundpython/imgs/anatomy.png\" width=\"900\" align=\"left\" style=\"margin: 0pt 0pt 0pt 250pt;\"/>\n",
+    "<img src=\"https://lund-observatory-teaching.github.io/lundpython/imgs/anatomy.png\" width=\"900\" align=\"left\" style=\"margin: 0pt 0pt 0pt 250pt;\"/>\n",
     "\n"
    ]
   },
@@ -102,7 +102,7 @@
     }
    },
    "source": [
-    "<img src=\"https://mikkolad.github.io/lundpython/imgs/anatomy.png\" width=\"900\" align=\"right\" style=\"margin: 0pt 0pt 0pt 0pt;\"/>\n",
+    "<img src=\"https://lund-observatory-teaching.github.io/lundpython/imgs/anatomy.png\" width=\"900\" align=\"right\" style=\"margin: 0pt 0pt 0pt 0pt;\"/>\n",
     "\n",
     "#### <span style=\"color:red\">Figure</span>\n",
     "The entire plotted thing.\n",
@@ -228,7 +228,7 @@
    },
    "outputs": [],
    "source": [
-    "plt.style.use('https://mikkolad.github.io/lundpython/3-plotting/presentation.mplstyle')"
+    "plt.style.use('https://lund-observatory-teaching.github.io/lundpython/3-plotting/presentation.mplstyle')"
    ]
   },
   {
@@ -425,7 +425,7 @@
     "What's wrong with this one?\n",
     "\n",
     "<center>\n",
-    "    <img src=\"https://mikkolad.github.io/lundpython/imgs/bad1.png\" width=\"1000\" align=\"middle\" style=\"margin: 0pt 0pt 0pt 0pt;\"/>\n",
+    "    <img src=\"https://lund-observatory-teaching.github.io/lundpython/imgs/bad1.png\" width=\"1000\" align=\"middle\" style=\"margin: 0pt 0pt 0pt 0pt;\"/>\n",
     "</center>\n"
    ]
   },
@@ -439,7 +439,7 @@
    "source": [
     "What's wrong with this figure?\n",
     "<center>\n",
-    "    <img src=\"https://mikkolad.github.io/lundpython/imgs/bad2.png\" width=\"1300\" align=\"middle\" style=\"margin: 0pt 0pt 0pt 0pt;\"/>\n",
+    "    <img src=\"https://lund-observatory-teaching.github.io/lundpython/imgs/bad2.png\" width=\"1300\" align=\"middle\" style=\"margin: 0pt 0pt 0pt 0pt;\"/>\n",
     "</center>"
    ]
   },
@@ -452,7 +452,7 @@
    },
    "source": [
     "<center>\n",
-    "    <img src=\"https://mikkolad.github.io/lundpython/imgs/bad3.png\" width=\"900\" align=\"middle\" style=\"margin: 0pt 0pt 0pt 0pt;\"/>\n",
+    "    <img src=\"https://lund-observatory-teaching.github.io/lundpython/imgs/bad3.png\" width=\"900\" align=\"middle\" style=\"margin: 0pt 0pt 0pt 0pt;\"/>\n",
     "</center>"
    ]
   },
@@ -465,7 +465,7 @@
    },
    "source": [
     "<center>\n",
-    "    <img src=\"https://mikkolad.github.io/lundpython/imgs/bad4.png\" width=\"1000\" align=\"middle\" style=\"margin: 0pt 0pt 0pt 0pt;\"/>\n",
+    "    <img src=\"https://lund-observatory-teaching.github.io/lundpython/imgs/bad4.png\" width=\"1000\" align=\"middle\" style=\"margin: 0pt 0pt 0pt 0pt;\"/>\n",
     "</center>"
    ]
   },
@@ -478,7 +478,7 @@
    },
    "source": [
     "<center>\n",
-    "    <img src=\"https://mikkolad.github.io/lundpython/imgs/bad5.png\" width=\"1300\" align=\"middle\" style=\"margin: 0pt 0pt 0pt 0pt;\"/>\n",
+    "    <img src=\"https://lund-observatory-teaching.github.io/lundpython/imgs/bad5.png\" width=\"1300\" align=\"middle\" style=\"margin: 0pt 0pt 0pt 0pt;\"/>\n",
     "</center>"
    ]
   },
@@ -492,7 +492,7 @@
    "source": [
     "What's wrong with this figure?\n",
     "<center>\n",
-    "    <img src=\"https://mikkolad.github.io/lundpython/imgs/bad6.png\" width=\"1900\" align=\"middle\" style=\"margin: 0pt 0pt 0pt 0pt;\"/>\n",
+    "    <img src=\"https://lund-observatory-teaching.github.io/lundpython/imgs/bad6.png\" width=\"1900\" align=\"middle\" style=\"margin: 0pt 0pt 0pt 0pt;\"/>\n",
     "</center>"
    ]
   },
@@ -519,7 +519,7 @@
     "\n",
     "It is important to consider which colormap to use when presenting data as some choices will highlight your results more. When it comes to unveiling structure, you might also want to use a logarithmic colormap. [Matplotlib's default colormap.](https://cran.r-project.org/web/packages/viridis/vignettes/intro-to-viridis.html)\n",
     "\n",
-    "<img src=\"https://mikkolad.github.io/lundpython/imgs/colormaps.jpeg\" width=\"1900\">"
+    "<img src=\"https://lund-observatory-teaching.github.io/lundpython/imgs/colormaps.jpeg\" width=\"1900\">"
    ]
   },
   {
@@ -536,7 +536,7 @@
     "\n",
     "Raster images are pixel arrays or bitmaps. Zooming makes the pixels larger and therefore more noticeable.\n",
     "<center>\n",
-    "    <img src=\"https://mikkolad.github.io/lundpython/imgs/vector_or_raster.jpeg\" width=\"1300\">\n",
+    "    <img src=\"https://lund-observatory-teaching.github.io/lundpython/imgs/vector_or_raster.jpeg\" width=\"1300\">\n",
     "</center>"
    ]
   },
@@ -628,7 +628,7 @@
    "source": [
     "### Exit question 2: The best improvement of the plot (see screen) would be...\n",
     "<center>\n",
-    "    <img src=\"https://mikkolad.github.io/lundpython/imgs/bad6.png\" width=\"1300\">\n",
+    "    <img src=\"https://lund-observatory-teaching.github.io/lundpython/imgs/bad6.png\" width=\"1300\">\n",
     "</center>\n",
     "$\\quad$<b>A)</b> adding lines to connect the points.<br>\n",
     "$\\quad$<b>B)</b> fitting a curve through the values.<br>\n",
@@ -689,7 +689,7 @@
  "metadata": {
   "celltoolbar": "Slideshow",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -703,7 +703,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/4-tools/manual.ipynb
+++ b/4-tools/manual.ipynb
@@ -309,7 +309,7 @@
     "\n",
     "A short demonstration of using this profiler in Spyder can be seen in the video below:\n",
     "\n",
-    "<video controls width=\"900\" src=\"https://mikkolad.github.io/lundpython/imgs/spyder_line_profiler.mov\" />"
+    "<video controls width=\"900\" src=\"https://lund-observatory-teaching.github.io/lundpython/imgs/spyder_line_profiler.mov\" />"
    ]
   },
   {
@@ -392,11 +392,11 @@
     "\n",
     "Once you have installed it, you will find the following button in your notebooks:\n",
     "\n",
-    "![](https://mikkolad.github.io/lundpython/RISE1.png)\n",
+    "![](https://lund-observatory-teaching.github.io/lundpython/RISE1.png)\n",
     "\n",
     "Which will take you into a presentation mode of your notebook. But before you do that, you need to specify which cells, both markdown and code, belong to a slide. For this, you will want to see slide types under `View > Cell Toolbar > Slideshow`, seen as <strong style=\"color:red\">a</strong> in the following figure:\n",
     "\n",
-    "![](https://mikkolad.github.io/lundpython/RISE2.png)\n",
+    "![](https://lund-observatory-teaching.github.io/lundpython/RISE2.png)\n",
     "\n",
     "Now you can see the slide type where <strong style=\"color:red\">b</strong> is in the above image. Every cell starting with `Slide` will be a new slide. Try out the other options to quickly figure out what they do.\n",
     "\n",
@@ -431,7 +431,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/4-tools/presentation.ipynb
+++ b/4-tools/presentation.ipynb
@@ -8,7 +8,7 @@
     }
    },
    "source": [
-    "<img src=\"https://mikkolad.github.io/lundpython/imgs/front_4.png\" width=\"1400\">"
+    "<img src=\"https://lund-observatory-teaching.github.io/lundpython/imgs/front_4.png\" width=\"1400\">"
    ]
   },
   {
@@ -23,7 +23,7 @@
     "\n",
     "To download all lecture files and see the schedule, please visit:\n",
     "\n",
-    "[mikkolad.github.io/lundpython/](https://mikkolad.github.io/lundpython/)\n",
+    "[lund-observatory-teaching.github.io/lundpython/](https://lund-observatory-teaching.github.io/lundpython/)\n",
     "\n",
     "\n",
     "Each lecture contains (as notebooks)\n",
@@ -464,7 +464,7 @@
     "\n",
     "A quick demonstration!\n",
     "\n",
-    "<video controls width=\"900\" src=\"https://mikkolad.github.io/lundpython/imgs/spyder_line_profiler.mov\" />"
+    "<video controls width=\"900\" src=\"https://lund-observatory-teaching.github.io/lundpython/imgs/spyder_line_profiler.mov\" />"
    ]
   },
   {
@@ -752,7 +752,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I changed all the image links in the presentations to point to the new `lund-observatory-teaching` host instead of the old `mikkolad` one. Also added Daniel to the "former teachers" list in the first presentation.
Also changed the "we recommend using Anaconda" cell in presentation 1 to one that says "we recommend you follow the Numpy guide". 