### PR TITLE
Improve formatting in `numpy` lesson manual

### DIFF
--- a/2-numpy/manual.ipynb
+++ b/2-numpy/manual.ipynb
@@ -24,7 +24,7 @@
    "outputs": [],
    "source": [
     "for elem in (5, \"5\", [5]):\n",
-    "    print(f\"If {elem} is a {type(elem)} instance, then {2*elem = }\")"
+    "    print(f\"{elem = } is {type(elem).__name__}, so {2 * elem = }\")"
    ]
   },
   {
@@ -337,9 +337,7 @@
     "print(f\"{column_vector.shape = }\\n\")\n",
     "\n",
     "# We could also convert the input into a row vector\n",
-    "row_vector = small_array[\n",
-    "    np.newaxis,\n",
-    "]\n",
+    "row_vector = small_array[np.newaxis, :]\n",
     "print(row_vector)\n",
     "print(f\"{row_vector.shape = }\\n\")\n",
     "\n",
@@ -350,13 +348,7 @@
     "print(column_vector - row_vector, \"\\n\")\n",
     "\n",
     "# We don't have to store the row and column vectors, so we could just write\n",
-    "print(\n",
-    "    small_array[:, np.newaxis]\n",
-    "    - small_array[\n",
-    "        np.newaxis,\n",
-    "    ],\n",
-    "    \"\\n\",\n",
-    ")\n",
+    "print(small_array[:, np.newaxis] - small_array[np.newaxis, :], \"\\n\")\n",
     "# But according to broadcasting rules the second broadcasting can be performed implicitly\n",
     "print(small_array[:, np.newaxis] - small_array)"
    ]
@@ -476,9 +468,8 @@
     "print()\n",
     "\n",
     "# It is possible to add new columns\n",
-    "data[\"density\"] = (data[\"mass\"] / (4 * np.pi / 3 * data[\"radius\"] ** 3)).to(\n",
-    "    u.g / u.cm**3\n",
-    ")\n",
+    "volume = 4 * np.pi / 3 * data[\"radius\"] ** 3\n",
+    "data[\"density\"] = (data[\"mass\"] / volume).to(u.g / u.cm**3)\n",
     "print(data)\n",
     "print()\n",
     "\n",


### PR DESCRIPTION
A few small improvements to the formatting of the `numpy` lesson manual. I did not notice code formatting problems in the presentation.