### PR TITLE
Remove course evaluation link from webpage and correct room in schedule

### DIFF
--- a/index.md
+++ b/index.md
@@ -40,7 +40,7 @@ function topFunction() {
   document.documentElement.scrollTop = 0;
 }
 </script>
-<h1><center>Click here: <a href="https://forms.gle/ANsp6V2uM3iSHFu89">Course evaluation</a></center></h1>
+<!-- <h1><center>Click here: <a href="https://forms.gle/ANsp6V2uM3iSHFu89">Course evaluation</a></center></h1> -->
 <h1><center>Your teachers </center></h1><br>
 <intro>
     <img align=left width=300 src="imgs/eero.jpeg">

--- a/schedule.md
+++ b/schedule.md
@@ -3,7 +3,7 @@ layout: default
 title: "Schedule"
 ---
 
-All lectures start in **Cassiopeia** and then move to **Lyra**
+All lectures are held in **Lyra**
 
 There are four lectures with the following dates and topics (HT2022):
 


### PR DESCRIPTION
I only commented out the course evaluation link since we will need it again soon. 