### PR TITLE
Rearrange the end of manual 4 and add links to scientific Python organization

### DIFF
--- a/4-tools/manual.ipynb
+++ b/4-tools/manual.ipynb
@@ -507,6 +507,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Version control\n",
+    "\n",
+    "It is a good idea to have some version control software manage your code. Not only would this allow you to restore older versions of your code repository, it can also help you to document how the code has evolved. If you are using [Git](https://git-scm.com) it is very simple to host your code (either privately or publicly) on [GitHub](https://github.com), [GitLab](https://gitlab.com) or [Bitbucket](https://bitbucket.org/) (this list is far from being complete). This functions both as a backup in the cloud but also allows you to easily share your code with your collaborators (or at the very least your supervisor), though Git can certainly be useful even if you never share your repository with anyone.\n",
+    "\n",
+    "If you are interested in version control then you can read more about it from [Chapter 1 Section 1 of the Pro Git book](https://git-scm.com/book/en/v2/Getting-Started-About-Version-Control). If you are interested in using Git then you can continue on reading the book.\n",
+    "\n",
     "## Slideshows\n",
     "\n",
     "Our presentations use a sort of \"slideshow\" version of Jupyter notebooks. There are a few ways this can be done, and we have used [RISE](https://rise.readthedocs.io/en/stable/#).\n",
@@ -521,11 +527,9 @@
     "\n",
     "Now you can see the slide type where <strong style=\"color:red\">b</strong> is in the above image. Every cell starting with `Slide` will be a new slide. Try out the other options to quickly figure out what they do.\n",
     "\n",
-    "## Version control\n",
+    "## Scientific Python\n",
     "\n",
-    "It is a good idea to have some version control software manage your code. Not only would this allow you to restore older versions of your code repository, it can also help you to document how the code has evolved. If you are using [Git](https://git-scm.com) it is very simple to host your code (either privately or publicly) on [GitHub](https://github.com), [GitLab](https://gitlab.com) or [Bitbucket](https://bitbucket.org/) (this list is far from being complete). This functions both as a backup in the cloud but also allows you to easily share your code with your collaborators (or at the very least your supervisor), though Git can certainly be useful even if you never share your repository with anyone.\n",
-    "\n",
-    "If you are interested in version control then you can read more about it from [Chapter 1 Section 1 of the Pro Git book](https://git-scm.com/book/en/v2/Getting-Started-About-Version-Control). If you are interested in using Git then you can continue on reading the book."
+    "The [scientific Python community](https://learn.scientific-python.org/development/) has tonnes of useful materials that can be greatly beneficial to advanced students. In particular, they have guidance on the [process](https://learn.scientific-python.org/development/principles/process/) (how coding projects should be conducted) and [design](https://learn.scientific-python.org/development/principles/design/) (how code should be written), as well as more in-depth guides on topics already covered like [style](https://learn.scientific-python.org/development/guides/style/), [testing](https://learn.scientific-python.org/development/guides/pytest/), and [writing documentation](https://learn.scientific-python.org/development/guides/docs/) and [much more](https://learn.scientific-python.org/development/guides/)."
    ]
   }
  ],

--- a/4-tools/manual.ipynb
+++ b/4-tools/manual.ipynb
@@ -529,7 +529,7 @@
     "\n",
     "## Scientific Python\n",
     "\n",
-    "The [scientific Python community](https://learn.scientific-python.org/development/) has tonnes of useful materials that can be greatly beneficial to advanced students. In particular, they have guidance on the [process](https://learn.scientific-python.org/development/principles/process/) (how coding projects should be conducted) and [design](https://learn.scientific-python.org/development/principles/design/) (how code should be written), as well as more in-depth guides on topics already covered like [style](https://learn.scientific-python.org/development/guides/style/), [testing](https://learn.scientific-python.org/development/guides/pytest/), and [writing documentation](https://learn.scientific-python.org/development/guides/docs/) and [much more](https://learn.scientific-python.org/development/guides/)."
+    "The [scientific Python community](https://learn.scientific-python.org/development/) has tonnes of useful materials that can be greatly beneficial to advanced students. In particular, they have guidance on the [process](https://learn.scientific-python.org/development/principles/process/) (how coding projects should be conducted) and [design](https://learn.scientific-python.org/development/principles/design/) (how code should be written), as well as more in-depth guides on topics already covered like [style](https://learn.scientific-python.org/development/guides/style/), [testing](https://learn.scientific-python.org/development/guides/pytest/), and [much more](https://learn.scientific-python.org/development/guides/)."
    ]
   }
  ],


### PR DESCRIPTION
Now, version control comes before the part about the slideshow.

The new section contains many links pointing to resources that are
intended for students who already have a firm grasp of the basics.
The links all go to pages within the scientific Python organization.