### PR TITLE
Update the link to RISE documentation

### DIFF
--- a/4-tools/manual.ipynb
+++ b/4-tools/manual.ipynb
@@ -501,7 +501,7 @@
    "source": [
     "## Slideshows\n",
     "\n",
-    "Our presentations use a sort of \"slideshow\" version of Jupyter notebooks. There are a few ways this can be done, and we have used [RISE](https://rise.readthedocs.io/en/master/).\n",
+    "Our presentations use a sort of \"slideshow\" version of Jupyter notebooks. There are a few ways this can be done, and we have used [RISE](https://rise.readthedocs.io/).\n",
     "\n",
     "Once you have installed it, you will find the following button in your notebooks:\n",
     "\n",

--- a/4-tools/manual.ipynb
+++ b/4-tools/manual.ipynb
@@ -501,7 +501,7 @@
    "source": [
     "## Slideshows\n",
     "\n",
-    "Our presentations use a sort of \"slideshow\" version of Jupyter notebooks. There are a few ways this can be done, and we have used [RISE](https://rise.readthedocs.io/en/stable/#).\n",
+    "Our presentations use a sort of \"slideshow\" version of Jupyter notebooks. There are a few ways this can be done, and we have used [RISE](https://rise.readthedocs.io/en/master/).\n",
     "\n",
     "Once you have installed it, you will find the following button in your notebooks:\n",
     "\n",


### PR DESCRIPTION
For some reason, the link to [stable](https://rise.readthedocs.io/en/stable/) gives a 404 but the link to [master](https://rise.readthedocs.io/en/master/) works fine.