### PR TITLE
Update presentation 4 and remove pycodestyle

### DIFF
--- a/4-tools/is_this_pep8.py
+++ b/4-tools/is_this_pep8.py
@@ -1,3 +1,3 @@
-a='This code is not PEP 8 compliant! Not only will pycodestyle get very upset, it will make sure you will be upset too.'
+a='This code is not PEP 8 compliant! Not only will the linter get very upset, it will make sure you will be upset too.'
 for sentence in a.split( '! ' ):
   print(sentence ,end ='\n\n')# Notice how the Python interpreter does not require 4 space indents

--- a/4-tools/manual.ipynb
+++ b/4-tools/manual.ipynb
@@ -23,9 +23,25 @@
     "\n",
     "## PEP 8\n",
     "\n",
-    "[The Python Style Guide](https://www.python.org/dev/peps/pep-0008/), commonly referred to as PEP 8, was already mentioned in the first lesson. Here we introduce tools that allow you to check if your code is PEP 8 compliant. One such tool is [pycodestyle](https://pypi.org/project/pycodestyle/). If you wish to check a Python script called 'helloworld.py' you would simply run\n",
+    "[The Python Style Guide](https://www.python.org/dev/peps/pep-0008/), commonly referred to as PEP 8, was already mentioned in the first lesson. Here we introduce tools that allow you to check if your code is PEP 8 compliant. \n",
+    "\n",
+    "## Ruff\n",
+    "\n",
+    "[Ruff](https://docs.astral.sh/ruff/) is a modern tool for checking codestyle (linting). The main difference between Ruff and earlier tools is that Ruff is much faster, making it possible for one tool to do work that might otherwise be split among several. Ruff can fix issues with obvious solutions and point out any others.\n",
+    "\n",
+    "If you wish to check a Python script called 'helloworld.py' you would simply run\n",
     "```\n",
-    "$ pycodestyle helloworld.py\n",
+    "$ ruff check helloworld.py\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The example above has produced more complaints than there are lines in the code, but all the error messages state exactly where the PEP 8 violations are located and what the problems are. This makes fixing them quite straightforward. It is also possible to get Ruff to automatically fix issues with simple solutions. To do this, run\n",
+    "```\n",
+    "$ ruff check --fix --show-fixes helloworld.py\n",
     "```"
    ]
   },
@@ -39,12 +55,6 @@
     "tags": []
    },
    "source": [
-    "The example above has produced more complaints than there are lines in the code, but all the error messages state exactly where the PEP 8 violations are located and what the problems are. This makes fixing them quite straightforward.\n",
-    "\n",
-    "## Ruff\n",
-    "\n",
-    "[Ruff](https://docs.astral.sh/ruff/) is a modern tool similar to pycodestyle. The main difference between Ruff and earlier tools is that Ruff is much faster, making it possible for one tool to do work that might otherwise be split among several. Ruff can fix issues with obvious solutions and point out any others.\n",
-    "\n",
     "To use Ruff, first [install](https://docs.astral.sh/ruff/installation/) it, then follow the [getting started](https://docs.astral.sh/ruff/tutorial/#getting-started) section of the documentation. You probably also want to go through the [configuration](https://docs.astral.sh/ruff/configuration/) to set up things like Jupyter notebook integration and shell auto-complete. \n",
     "\n",
     "## `black`\n",
@@ -114,7 +124,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Inside a Jupyter notebook you can use the IPython commands `?` and `?? ` to view the docstring and source code of a function respectively. Because these are IPython commands rather than normal Python commands, pycodestyle will think they are a syntax error, but this is not a problem for Jupyter."
+    "Inside a Jupyter notebook you can use the IPython commands `?` and `?? ` to view the docstring and source code of a function respectively. Because these are IPython commands rather than normal Python commands, some linters may think they are syntax errors, but this is not a problem for Jupyter."
    ]
   },
   {

--- a/4-tools/presentation.ipynb
+++ b/4-tools/presentation.ipynb
@@ -462,7 +462,7 @@
    },
    "outputs": [],
    "source": [
-    "a = \"This code is not PEP 8 compliant! Not only will pycodestyle get very upset, it will make sure you will be upset too.\"\n",
+    "a = \"This code is not PEP 8 compliant! Not only will the linter get very upset, it will make sure you will be upset too.\"\n",
     "for sentence in a.split(\"! \"):\n",
     "    print(\n",
     "        sentence, end=\"\\n\\n\"\n",

--- a/4-tools/presentation.ipynb
+++ b/4-tools/presentation.ipynb
@@ -282,17 +282,17 @@
     "%%heat\n",
     "\n",
     "def sieve(n):\n",
-    "    primes=[]\n",
-    "    test=list(range(2,n+1) )\n",
-    "    while test[0]<=n**0.5:\n",
+    "    primes = []\n",
+    "    test = list(range(2, n + 1))\n",
+    "    while test[0] <= n**0.5:\n",
     "        p = test.pop(0) \n",
     "        primes.append(p)\n",
     "        new_list = []\n",
     "        for n in test:\n",
-    "            if n%p:\n",
+    "            if n % p:\n",
     "                new_list.append(n) \n",
     "        test = new_list\n",
-    "    return primes+test\n",
+    "    return primes + test\n",
     "\n",
     "primes = sieve(5000)\n",
     "print(len(primes))"
@@ -434,19 +434,18 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "# PEP8\n",
     "\n",
     "Recall from lecture 1 [The Python Style Guide](https://www.python.org/dev/peps/pep-0008/) a.k.a. PEP8.  \n",
     "\n",
-    "It is a lengthy document that can be hard to memorize. Instead, there are nifty tools one can use to check the PEP8 compliance of a script. Consider for example [pycodestyle](https://pypi.org/project/pycodestyle/). Once it has been installed on your system, you can check a script with the following command.\n",
-    "\n",
-    "`pycodestyle is_this_pep8.py`\n",
-    "##### Run in terminal\n",
+    "It is a lengthy document that can be hard to memorize. Instead, there are nifty tools one can use to check the PEP8 compliance of a script and/or fix issues automatically. Here we will be looking at two of the most prominent such tools and demonstrating them against the code below.\n",
     "\n",
     "##### Code example:"
    ]
@@ -454,7 +453,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "a = \"This code is not PEP 8 compliant! Not only will pycodestyle get very upset, it will make sure you will be upset too.\"\n",
@@ -466,7 +471,13 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": "slide"
+    },
+    "tags": []
+   },
    "source": [
     "# [`Ruff`](https://docs.astral.sh/ruff/)\n",
     "\n",
@@ -475,33 +486,36 @@
     "It can fix some issues automatically and has several editor integrations. To run it (once installed), use the following command.\n",
     "\n",
     "`ruff check is_this_pep8.py`\n",
-    "##### Run in terminal and compare results.\n",
-    "\n"
+    "##### Run in terminal.\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "# [`black`](https://pypi.org/project/black/)\n",
     "\n",
-    "`black` is an automatic code formater. When `black` is run on a script it will change to code into its style, taking the decision away from the user. This means that code formatted with `black` has a very consistent look.\n",
+    "`black` is an automatic code formater. When `black` is run on a script it will change the code into its style, taking the decision away from the user. This means that code formatted with `black` has a very consistent look.\n",
     "\n",
     "All the code demonstrated in this course has been formtated with `black` (except for the deliberately bad examples). \n",
     "\n",
-    "Automatic code formaters like `black` are very useful for collaborative projects. It is already used by pytest, pandas, Django and Astropy (WIP) and Dropbox, Mozilla, Duolingo, Facebook etc. "
+    "Automatic code formaters like `black` are very useful for collaborative projects. It is already used by pytest, pandas, Django, Astropy, Dropbox, Mozilla, Duolingo, Facebook etc. "
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "##### Before applying `black`\n",
@@ -529,9 +543,11 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "subslide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "##### After applying `black`\n",
@@ -641,9 +657,11 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "-"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -655,9 +673,11 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "Jupyter notebook also has some useful ways of accessing docstrings. We can use<code style=\"color:#AA29FF\"><b>?</b></code> and <code style=\"color:#AA29FF\"><b>??</b></code> for example to access the docstring and source code respectively"
@@ -667,9 +687,11 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "-"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -680,9 +702,11 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "-"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -692,22 +716,32 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "-"
-    }
+    },
+    "tags": []
    },
    "source": [
     "We can also utilize `Shift + Tab` inside a function.  \n",
     "1 `Tab` brings up a brief docstring.  \n",
     "2 `Tab` makes it bigger.  \n",
     "3 `Tab` makes it linger for 10 seconds.  \n",
-    "4 `Tab` opens the pager."
+    "4 `Tab` opens the pager.\n",
+    "\n",
+    "Jupyter lab only shows the long description."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "identity()"
@@ -716,9 +750,11 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "# Progress bars\n",
@@ -730,9 +766,11 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -751,9 +789,11 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "Inside a Jupyter notebook you might prefer to use the versions of the functions defined in `tqdm.notebook`."
@@ -763,9 +803,11 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -781,7 +823,13 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "# Git\n",
     "\n",


### PR DESCRIPTION
Fix the formatting in one cell that `black` does not seem to touch. 
Removed the description of `pycodestyle` completely and rearranged the section a bit.
Removed the (WIP) note on `astropy` using `black`.