### PR TITLE
Minor fixes for session 4

### DIFF
--- a/4-tools/presentation.ipynb
+++ b/4-tools/presentation.ipynb
@@ -468,11 +468,9 @@
    },
    "outputs": [],
    "source": [
-    "a = \"This code is not PEP 8 compliant! Not only will the linter get very upset, it will make sure you will be upset too.\"\n",
-    "for sentence in a.split(\"! \"):\n",
-    "    print(\n",
-    "        sentence, end=\"\\n\\n\"\n",
-    "    )  # Notice how the Python interpreter does not require 4 space indents"
+    "a='This code is not PEP 8 compliant! Not only will the linter get very upset, it will make sure you will be upset too.'\n",
+    "for sentence in a.split( '! ' ):\n",
+    "  print(sentence ,end ='\\n\\n')# Notice how the Python interpreter does not require 4 space indents\""
    ]
   },
   {

--- a/4-tools/presentation.ipynb
+++ b/4-tools/presentation.ipynb
@@ -3,9 +3,11 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "<img src=\"https://lund-observatory-teaching.github.io/lundpython/imgs/front_4.jpeg\" width=\"1400\">"
@@ -355,9 +357,11 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
-    }
+    },
+    "tags": []
    },
    "source": [
     "# Command line\n",
@@ -374,9 +378,11 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "editable": true,
     "slideshow": {
      "slide_type": "-"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -704,7 +710,7 @@
    "metadata": {
     "editable": true,
     "slideshow": {
-     "slide_type": "-"
+     "slide_type": "subslide"
     },
     "tags": []
    },
@@ -718,7 +724,7 @@
    "metadata": {
     "editable": true,
     "slideshow": {
-     "slide_type": "-"
+     "slide_type": "subslide"
     },
     "tags": []
    },
@@ -826,7 +832,7 @@
    "metadata": {
     "editable": true,
     "slideshow": {
-     "slide_type": ""
+     "slide_type": "slide"
     },
     "tags": []
    },


### PR DESCRIPTION
Some slides were not divided in the best or correct way, and the bad code example in the slides had been made good. 
This PR adjusts some slides in Presentation 4 and restores the badness in the code example (in the slides, the one in is_this_pep8.py was as bad as it should be).