### PR TITLE
Ruff rules and lecture_function fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes"]
-        exclude: ^4-tools/is_this_pep8.py
+        exclude: 4-tools/is_this_pep8.py
 
 - repo: https://github.com/codespell-project/codespell
   rev: "v2.2.6"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ repos:
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes"]
+        exclude: ^4-tools/is_this_pep8.py
 
 - repo: https://github.com/codespell-project/codespell
   rev: "v2.2.6"

--- a/2-numpy/lecture_functions.py
+++ b/2-numpy/lecture_functions.py
@@ -15,12 +15,12 @@ def cart2polar(arr):
     Parameters
     ----------
     arr : numpy.ndarray
-    An array of cartesian coordinates.
+        An array of cartesian coordinates.
 
     Returns
     -------
     numpy.ndarray
-    An array of polar coordinates.
+        An array of polar coordinates.
     """
     return np.array((np.linalg.norm(arr, axis=1), np.arctan2(arr[:, 1], arr[:, 0]))).T
 

--- a/2-numpy/lecture_functions.py
+++ b/2-numpy/lecture_functions.py
@@ -1,7 +1,7 @@
 """
 File containing functions that are used in the notebooks.
 
-The function in this file are related to tranforming coordinates
+The functions in this file are related to transforming coordinates
 and making and plotting polynomials.
 """
 import matplotlib.pyplot as plt
@@ -14,12 +14,12 @@ def cart2polar(arr):
 
     Parameters
     ----------
-    arr : numpy array
+    arr : numpy.ndarray
     An array of cartesian coordinates.
 
     Returns
     -------
-    numpy array
+    numpy.ndarray
     An array of polar coordinates.
     """
     return np.array((np.linalg.norm(arr, axis=1), np.arctan2(arr[:, 1], arr[:, 0]))).T
@@ -31,12 +31,12 @@ def cart2spherical(arr):
 
     Parameters
     ----------
-    arr : numpy array
+    arr : numpy.ndarray
     An array of cartesian coordinates.
 
     Returns
     -------
-    numpy array
+    numpy.ndarray
     An array of spherical coordinates.
     """
     r = np.linalg.norm(arr, axis=1)
@@ -47,7 +47,7 @@ def cart2spherical(arr):
 
 def polynomial_xy(npoints):
     """
-    Generate x and y data for a polynomial.
+    Generate random x and y data for a polynomial.
 
     Parameters
     ----------
@@ -57,7 +57,7 @@ def polynomial_xy(npoints):
     Returns
     -------
     tuple
-    A tuple containing x and y data, both are nunpy arrays.
+    A tuple containing x and y data, both are numpy arrays.
     """
     rng = np.random.default_rng()
     x = np.linspace(-5, 5, npoints)
@@ -71,20 +71,10 @@ def plot_polynomial(x, y, a=None, b=None, c=None):
 
     Parameters
     ----------
-    x : numpy array
+    x : numpy.ndarray
         The x values.
 
-    y : numpy array
-        The y values.
-
-    a : Plot a polynomial.
-
-    Parameters
-    ----------
-    x : numpy array
-        The x values.
-
-    y : numpy array
+    y : numpy.ndarray
         The y values.
 
     a : float, optional
@@ -106,4 +96,3 @@ def plot_polynomial(x, y, a=None, b=None, c=None):
     plt.xlabel("$x$", fontsize=14)
     plt.xticks(fontsize=10)
     plt.yticks(fontsize=10)
-    plt.plot()

--- a/2-numpy/lecture_functions.py
+++ b/2-numpy/lecture_functions.py
@@ -32,12 +32,12 @@ def cart2spherical(arr):
     Parameters
     ----------
     arr : numpy.ndarray
-    An array of cartesian coordinates.
+        An array of cartesian coordinates.
 
     Returns
     -------
     numpy.ndarray
-    An array of spherical coordinates.
+        An array of spherical coordinates.
     """
     r = np.linalg.norm(arr, axis=1)
     theta = np.arctan2(np.linalg.norm(arr[:, :2], axis=1), arr[:, 2])
@@ -52,12 +52,14 @@ def polynomial_xy(npoints):
     Parameters
     ----------
     npoints : int
-    The number of points to generate.
+        The number of points to generate.
 
     Returns
     -------
-    tuple
-    A tuple containing x and y data, both are numpy arrays.
+    x_coords : numpy.ndarray
+        x-coordinates of the data points.
+    y_coords : numpy.ndarray
+        y-coordinates of the data points.
     """
     rng = np.random.default_rng()
     x = np.linspace(-5, 5, npoints)

--- a/4-tools/sieve.py
+++ b/4-tools/sieve.py
@@ -1,4 +1,4 @@
-@profile
+@profile  # noqa: F821, D100
 def sieve(n):
     """Return a list of all primes up to integer n.
 
@@ -22,4 +22,4 @@ def sieve(n):
 
 
 primes = sieve(5000)
-print(len(primes))
+print(len(primes))  # noqa: T201

--- a/4-tools/sieve.py
+++ b/4-tools/sieve.py
@@ -1,4 +1,6 @@
-@profile  # noqa: F821, D100
+# ruff: noqa: D100
+
+@profile  # noqa: F821
 def sieve(n):
     """Return a list of all primes up to integer n.
 

--- a/4-tools/sieve.py
+++ b/4-tools/sieve.py
@@ -21,5 +21,6 @@ def sieve(n):
     return primes + test
 
 
-primes = sieve(5000)
-print(len(primes))  # noqa: T201
+if __name__ == "__main__":
+    primes = sieve(5000)
+    print(len(primes))  # noqa: T201

--- a/ruff.toml
+++ b/ruff.toml
@@ -6,13 +6,6 @@ ignore = [
     "COM819",   # TrailingCommaProhibited
 ]
 
-[lint.per-file-ignores]
-"4-tools/is_this_pep8.py" = ["ALL"] # This file is intentionally bad
-"4-tools/sieve.py" = [
-    "T201",     # The print is intentional
-    "F821",     # This catches the profiling decorator
-    "D100",     # Using a module docstring here is overkill
-]
 [pydocstyle]
 convention = "numpy"
 


### PR DESCRIPTION
I missed a few things in #85, this PR aims to address that. 
Most severely, it was not possible to demonstrate ruff on is_this_pep8.py because there was a rule to ignore that file in rull.toml. This has been changed so that the pre-commit hook ignores the file instead.
The rest of the changes are mostly the language in the docstrings in lecture_functions.