### PR TITLE
Update downloads.md

### DIFF
--- a/downloads.md
+++ b/downloads.md
@@ -36,6 +36,3 @@ Here you will find the course material for the python programming course @ Lund 
 ##### Additional content
 <a href="{{site.github.url}}/4-tools/xy.txt" download>xy.txt</a><br>
 <a href="{{site.github.url}}/4-tools/is_this_pep8.py" download>is_this_pep8.py</a><br>
-
-## ASTM22
-<a href="{{site.github.url}}/ASTM22/TipsAndTricks.ipynb" download>TipsAndTricks.ipynb</a><br>


### PR DESCRIPTION
Remove download link for ASTM22 notebook. The notebook itself was removed some time ago so the link is dead.