### PR TITLE
Add ipywidgets to required packages

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ ipytest = "*"
 line-profiler = "*"
 jupyterlab-rise = "*"
 tqdm = "*"
+ipywidgets = "*"
 
 [dev-packages]
 pre-commit = "*"


### PR DESCRIPTION
Ipywidgets is required to run the tqdm.notebook functions demonstrated in presentation 4. 
This time around, this package needed to be installed manually. It is unknown to me what has changed to cause this to be needed. 
Adding ipywidgets also makes the regular tqdm progress bars look nicer (as nice as they used to be).